### PR TITLE
Manage and organize git branch

### DIFF
--- a/Modules/Common/PowerShellMagic.Common.psd1
+++ b/Modules/Common/PowerShellMagic.Common.psd1
@@ -9,7 +9,22 @@
         'Get-PSMagicConfigPath',
         'Copy-PSMagicHashtable',
         'Test-FzfAvailable',
-        'Test-PSMagicNonInteractive'
+        'Test-PSMagicNonInteractive',
+        # Config caching functions
+        'Initialize-PSMagicConfigCache',
+        'Get-PSMagicCachedConfig',
+        'Clear-PSMagicConfigCache',
+        'Remove-PSMagicConfigCache',
+        # Compiled regex functions
+        'Get-PSMagicCompiledRegex',
+        'Clear-PSMagicCompiledRegexCache',
+        'Get-PSMagicCommonRegex',
+        'Test-PSMagicRegexPerformance',
+        # Help system functions
+        'Test-PSMagicHelpRequest',
+        'Show-PSMagicHelp',
+        'Add-PSMagicArgumentCompleter',
+        'Initialize-PSMagicHelpSystem'
     )
     AliasesToExport = @()
     PrivateData = @{


### PR DESCRIPTION
## Root Cause
The PowerShellMagic.Common.psd1 manifest file only exported the four original helper functions, not the new functions from Private modules (ConfigCache, CompiledRegex, HelpSupport). Even though the .psm1 file used Export-ModuleMember to export these functions, the .psd1 manifest's FunctionsToExport takes precedence and restricted what was actually exported from the module.

## Impact
This caused all Pester tests to fail with errors like: "The term 'Get-PSMagicCachedConfig' is not recognized as a name of a cmdlet, function, script file, or executable program."

The QuickJump, Templater, and Unitea modules import the Common module and expect to use functions like Get-PSMagicCachedConfig, but they weren't actually available because they weren't in the manifest's FunctionsToExport list.

## Changes
Updated Modules/Common/PowerShellMagic.Common.psd1 to export all functions from Private modules:
- Initialize-PSMagicConfigCache
- Get-PSMagicCachedConfig
- Clear-PSMagicConfigCache
- Remove-PSMagicConfigCache
- Get-PSMagicCompiledRegex
- Clear-PSMagicCompiledRegexCache
- Get-PSMagicCommonRegex
- Test-PSMagicRegexPerformance
- Test-PSMagicHelpRequest
- Show-PSMagicHelp
- Add-PSMagicArgumentCompleter
- Initialize-PSMagicHelpSystem

This aligns the .psd1 manifest with the .psm1 Export-ModuleMember list.

## Testing
This fix should resolve all 16 failing Pester tests related to missing Common module functions.