### PR TITLE
Set up CI/CD matrix testing across operating systems

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -39,23 +39,23 @@ jobs:
 
       - name: Run lint check (no auto-fix)
         id: lint
-        continue-on-error: true
         run: |
           pre-commit install
           # Run pre-commit in check-only mode (will fail if changes needed)
-          if ! pre-commit run --all-files; then
+          if pre-commit run --all-files; then
+            echo "lint_failed=false" >> $GITHUB_OUTPUT
+            echo "Lint check passed - no fixes needed"
+          else
             echo "lint_failed=true" >> $GITHUB_OUTPUT
             echo "Lint check failed - fixes needed"
             exit 1
-          else
-            echo "lint_failed=false" >> $GITHUB_OUTPUT
-            echo "Lint check passed - no fixes needed"
           fi
 
   lint-fix:
     name: Auto-fix Lint Issues
     needs: lint-check
-    if: needs.lint-check.outputs.lint_failed == 'true'
+    # Run if lint-check failed (use always() to run even when previous job failed)
+    if: always() && needs.lint-check.outputs.lint_failed == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,7 +11,51 @@ permissions:
   pull-requests: write
 
 jobs:
-  lint:
+  lint-check:
+    name: Lint Check
+    runs-on: ubuntu-latest
+    outputs:
+      lint_failed: ${{ steps.lint.outputs.lint_failed }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.x'
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+
+      - name: Install pre-commit
+        run: |
+          python -m pip install --upgrade pip
+          pip install pre-commit
+
+      - name: Run lint check (no auto-fix)
+        id: lint
+        continue-on-error: true
+        run: |
+          pre-commit install
+          # Run pre-commit in check-only mode (will fail if changes needed)
+          if ! pre-commit run --all-files; then
+            echo "lint_failed=true" >> $GITHUB_OUTPUT
+            echo "Lint check failed - fixes needed"
+            exit 1
+          else
+            echo "lint_failed=false" >> $GITHUB_OUTPUT
+            echo "Lint check passed - no fixes needed"
+          fi
+
+  lint-fix:
+    name: Auto-fix Lint Issues
+    needs: lint-check
+    if: needs.lint-check.outputs.lint_failed == 'true'
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -37,7 +81,7 @@ jobs:
           pip install pre-commit
 
       - name: Run pre-commit with auto-fix
-        id: lint
+        id: fix
         run: |
           pre-commit install
           pwsh -NoProfile -File .\Scripts\Run-PreCommit.ps1
@@ -48,13 +92,13 @@ jobs:
           }
 
       - name: Configure git
-        if: steps.lint.outputs.changes == 'true'
+        if: steps.fix.outputs.changes == 'true'
         run: |
           git config user.name "github-actions"
           git config user.email "github-actions@github.com"
 
       - name: Commit fixes to current branch
-        if: steps.lint.outputs.changes == 'true' && (github.actor == github.repository_owner || github.actor == 'dependabot[bot]')
+        if: steps.fix.outputs.changes == 'true' && (github.actor == github.repository_owner || github.actor == 'dependabot[bot]')
         env:
           TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
         run: |
@@ -63,7 +107,7 @@ jobs:
           git push origin $Env:TARGET_BRANCH
 
       - name: Commit fixes to new branch
-        if: steps.lint.outputs.changes == 'true' && !(github.actor == github.repository_owner || github.actor == 'dependabot[bot]')
+        if: steps.fix.outputs.changes == 'true' && !(github.actor == github.repository_owner || github.actor == 'dependabot[bot]')
         env:
           TARGET_BRANCH: ${{ github.head_ref || github.ref_name }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -34,11 +34,46 @@ jobs:
           Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)" -ForegroundColor Cyan
           Write-Host "Operating System: ${{ matrix.os }}" -ForegroundColor Cyan
 
-      - name: Run Tests
+      - name: Install Pester
         run: |
+          Write-Host "Installing Pester 5.x for testing..." -ForegroundColor Cyan
+          Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
+          $pester = Get-Module -Name Pester -ListAvailable | Select-Object -First 1
+          Write-Host "Installed Pester version: $($pester.Version)" -ForegroundColor Green
+
+      - name: Run formatting checks
+        run: |
+          Write-Host "Running PowerShell formatting checks..." -ForegroundColor Cyan
+          ./Format-PowerShell.ps1 -Check
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Formatting check failed"
+            exit $LASTEXITCODE
+          }
+
+      - name: Run unit tests
+        run: |
+          Write-Host "Running PowerShell unit tests..." -ForegroundColor Cyan
+          ./Tests/Test-PowerShellMagic.ps1
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Unit tests failed"
+            exit $LASTEXITCODE
+          }
+
+      - name: Run comprehensive test suite
+        run: |
+          Write-Host "Running comprehensive test suite..." -ForegroundColor Cyan
           ./Run-Tests.ps1 -CI
           if ($LASTEXITCODE -ne 0) {
-            Write-Error "Tests failed on ${{ matrix.os }}"
+            Write-Error "Test suite failed on ${{ matrix.os }}"
+            exit $LASTEXITCODE
+          }
+
+      - name: Run Pester tests with code coverage
+        run: |
+          Write-Host "Running Pester test suite with code coverage..." -ForegroundColor Cyan
+          ./Invoke-PesterTests.ps1 -CI -CoverageThreshold 52
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Pester tests failed"
             exit $LASTEXITCODE
           }
 

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -13,7 +13,38 @@ env:
   BUILD_OUTPUT_DIR: out
 
 jobs:
+  test:
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    defaults:
+      run:
+        shell: pwsh
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup PowerShell environment
+        run: |
+          Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)" -ForegroundColor Cyan
+          Write-Host "Operating System: ${{ matrix.os }}" -ForegroundColor Cyan
+
+      - name: Run Tests
+        run: |
+          ./Run-Tests.ps1 -CI
+          if ($LASTEXITCODE -ne 0) {
+            Write-Error "Tests failed on ${{ matrix.os }}"
+            exit $LASTEXITCODE
+          }
+
   build:
+    name: Build Modules
+    needs: test
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -26,9 +57,6 @@ jobs:
           Install-Module PowerShellGet -Scope CurrentUser -Force -AllowClobber
           Import-Module PowerShellGet -Force
         shell: pwsh
-
-      - name: Run Tests
-        run: pwsh -NoProfile -File .\Run-Tests.ps1 -CI
 
       - name: Build modules
         run: pwsh -NoProfile -File .\Scripts\Build-Modules.ps1 -OutputPath $env:BUILD_OUTPUT_DIR

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,13 +68,12 @@ jobs:
     - name: Run markdown lint
       if: matrix.os == 'ubuntu-latest'
       run: |
-        Write-Host "Running markdownlint with auto-fix..." -ForegroundColor Cyan
+        Write-Host "Running markdownlint check..." -ForegroundColor Cyan
         if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
           Write-Error "npx (Node.js) is required to run markdownlint-cli"
           exit 1
         }
-        npx markdownlint-cli@0.41.0 --config .markdownlint.json --fix . --ignore CHANGELOG.md
-        git diff --name-only --exit-code
+        npx markdownlint-cli@0.41.0 --config .markdownlint.json . --ignore CHANGELOG.md
 
     - name: Run unit tests
       run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,14 @@ on:
 
 jobs:
   test:
-    name: Test PowerShell Magic
-    runs-on: windows-latest
+    name: Test (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     # Skip if triggered by workflow_run and the lint workflow failed
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     defaults:
       run:
         shell: pwsh
@@ -31,6 +35,7 @@ jobs:
     - name: Show trigger context
       run: |
         Write-Host "Event name: ${{ github.event_name }}" -ForegroundColor Cyan
+        Write-Host "Operating System: ${{ matrix.os }}" -ForegroundColor Cyan
         Write-Host "Current HEAD: $(git rev-parse HEAD)"
         Write-Host "Latest commit: $(git log -1 --pretty='%h %s')"
         if ("${{ github.event_name }}" -eq "workflow_run") {
@@ -54,13 +59,14 @@ jobs:
     - name: Run formatting checks
       run: |
         Write-Host "Running PowerShell formatting checks..." -ForegroundColor Cyan
-        .\Format-PowerShell.ps1 -Check
+        ./Format-PowerShell.ps1 -Check
         if ($LASTEXITCODE -ne 0) {
           Write-Error "Formatting check failed"
           exit $LASTEXITCODE
         }
 
     - name: Run markdown lint
+      if: matrix.os == 'ubuntu-latest'
       run: |
         Write-Host "Running markdownlint with auto-fix..." -ForegroundColor Cyan
         if (-not (Get-Command npx -ErrorAction SilentlyContinue)) {
@@ -73,7 +79,7 @@ jobs:
     - name: Run unit tests
       run: |
         Write-Host "Running PowerShell unit tests..." -ForegroundColor Cyan
-        .\Tests\Test-PowerShellMagic.ps1
+        ./Tests/Test-PowerShellMagic.ps1
         if ($LASTEXITCODE -ne 0) {
           Write-Error "Unit tests failed"
           exit $LASTEXITCODE
@@ -82,7 +88,7 @@ jobs:
     - name: Run comprehensive test suite
       run: |
         Write-Host "Running comprehensive test suite..." -ForegroundColor Cyan
-        .\Run-Tests.ps1 -CI
+        ./Run-Tests.ps1 -CI
         if ($LASTEXITCODE -ne 0) {
           Write-Error "Test suite failed"
           exit $LASTEXITCODE
@@ -91,7 +97,7 @@ jobs:
     - name: Run Pester tests with code coverage
       run: |
         Write-Host "Running Pester test suite with code coverage..." -ForegroundColor Cyan
-        .\Invoke-PesterTests.ps1 -CI -CoverageThreshold 52
+        ./Invoke-PesterTests.ps1 -CI -CoverageThreshold 52
         if ($LASTEXITCODE -ne 0) {
           Write-Error "Pester tests failed"
           exit $LASTEXITCODE
@@ -101,7 +107,7 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6
       with:
-        name: test-results
+        name: test-results-${{ matrix.os }}
         path: |
           **/*.log
           **/*.xml
@@ -111,16 +117,20 @@ jobs:
       if: always()
       uses: actions/upload-artifact@v6
       with:
-        name: code-coverage
+        name: code-coverage-${{ matrix.os }}
         path: |
           Tests/Pester/coverage.xml
           Tests/Pester/testResults.xml
         retention-days: 30
 
   validate-modules:
-    name: Validate PowerShell Modules
-    runs-on: windows-latest
+    name: Validate Modules (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     defaults:
       run:
         shell: pwsh
@@ -135,12 +145,12 @@ jobs:
 
     - name: Test module imports
       run: |
-        Write-Host "Testing PowerShell module imports..." -ForegroundColor Cyan
+        Write-Host "Testing PowerShell module imports on ${{ matrix.os }}..." -ForegroundColor Cyan
 
         $modules = @(
-          ".\Modules\QuickJump\QuickJump.psm1",
-          ".\Modules\Templater\Templater.psm1",
-          ".\Modules\Unitea\Unitea.psm1"
+          "./Modules/QuickJump/QuickJump.psm1",
+          "./Modules/Templater/Templater.psm1",
+          "./Modules/Unitea/Unitea.psm1"
         )
 
         $success = $true
@@ -169,9 +179,13 @@ jobs:
         if ((Test-Path -LiteralPath variable:\LASTEXITCODE)) { exit $LASTEXITCODE }
 
   security-scan:
-    name: Security Scan
-    runs-on: windows-latest
+    name: Security Scan (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
     if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
     defaults:
       run:
         shell: pwsh
@@ -186,20 +200,20 @@ jobs:
 
     - name: Run PSScriptAnalyzer security rules
       run: |
-        Write-Host "Running security analysis..." -ForegroundColor Cyan
+        Write-Host "Running security analysis on ${{ matrix.os }}..." -ForegroundColor Cyan
 
         # Install PSScriptAnalyzer if not available
         if (!(Get-Module -ListAvailable -Name PSScriptAnalyzer)) {
           Install-Module -Name PSScriptAnalyzer -Force -Scope CurrentUser
         }
 
-        # Get all PowerShell files
+        # Get all PowerShell files (cross-platform compatible path matching)
         $files = Get-ChildItem -Recurse -Include "*.ps1", "*.psm1", "*.psd1" -ErrorAction SilentlyContinue | Where-Object {
           $null -ne $_ -and
           $null -ne $_.FullName -and
-          $_.FullName -notmatch "\\\.git\\" -and
-          $_.FullName -notmatch "\\bin\\" -and
-          $_.FullName -notmatch "\\obj\\"
+          $_.FullName -notmatch '[/\\]\.git[/\\]' -and
+          $_.FullName -notmatch '[/\\]bin[/\\]' -and
+          $_.FullName -notmatch '[/\\]obj[/\\]'
         }
 
         if ($null -eq $files -or $files.Count -eq 0) {
@@ -242,52 +256,3 @@ jobs:
         }
 
         Write-Host "Security scan completed successfully!" -ForegroundColor Green
-
-  matrix-test:
-    name: Cross-Platform Compatibility
-    runs-on: ${{ matrix.os }}
-    if: ${{ github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success' }}
-    strategy:
-      matrix:
-        os: [windows-latest, ubuntu-latest, macos-latest]
-    defaults:
-      run:
-        shell: pwsh
-
-    steps:
-    - name: Checkout repository
-      uses: actions/checkout@v6
-      with:
-        # For workflow_run, checkout the branch to get latest commits (including auto-fix commits)
-        ref: ${{ github.event_name == 'workflow_run' && github.event.workflow_run.head_branch || '' }}
-        fetch-depth: 0
-
-    - name: Show PowerShell environment
-      run: |
-        Write-Host "Operating System: $($PSVersionTable.OS)" -ForegroundColor Cyan
-        Write-Host "PowerShell Version: $($PSVersionTable.PSVersion)" -ForegroundColor Cyan
-
-    - name: Install Pester
-      run: |
-        Write-Host "Installing Pester 5.x..." -ForegroundColor Cyan
-        Install-Module -Name Pester -MinimumVersion 5.0.0 -Force -SkipPublisherCheck -Scope CurrentUser
-        $pester = Get-Module -Name Pester -ListAvailable | Select-Object -First 1
-        Write-Host "Installed Pester version: $($pester.Version)" -ForegroundColor Green
-
-    - name: Run unit tests
-      run: |
-        Write-Host "Running platform-specific unit tests..." -ForegroundColor Cyan
-        ./Tests/Test-PowerShellMagic.ps1
-        if ($LASTEXITCODE -ne 0) {
-          Write-Error "Unit tests failed"
-          exit $LASTEXITCODE
-        }
-
-    - name: Run cross-platform test suite
-      run: |
-        Write-Host "Running full CI test suite..." -ForegroundColor Cyan
-        ./Run-Tests.ps1 -CI
-        if ($LASTEXITCODE -ne 0) {
-          Write-Error "Cross-platform test suite failed"
-          exit $LASTEXITCODE
-        }

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,6 +44,7 @@ repos:
           - './Scripts/Test-MarkdownLinks.ps1'
         language: system
         files: '\.(md|markdown)$'
+        pass_filenames: false
 
   # General file checks
   - repo: https://github.com/pre-commit/pre-commit-hooks

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,40 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery and unwelcome sexual attention
+- Trolling, insulting/derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project maintainers. All complaints will be reviewed
+and investigated and will result in a response that is deemed necessary and
+appropriate to the circumstances.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.0.

--- a/Scripts/Test-MarkdownLinks.ps1
+++ b/Scripts/Test-MarkdownLinks.ps1
@@ -64,7 +64,13 @@ function Resolve-MarkdownPath {
         return $null
     }
 
-    $pathPart = $pathPart.TrimStart()
+    $pathPart = $pathPart.TrimStart().TrimEnd('.')
+
+    # Validate and resolve base directory
+    if (-not (Test-Path -LiteralPath $BaseDirectory -PathType Container)) {
+        Write-Warning "Base directory not found: $BaseDirectory"
+        return $null
+    }
 
     $root = (Get-Item -LiteralPath $BaseDirectory).FullName
     $workspaceRoot = (Get-Location).ProviderPath


### PR DESCRIPTION
- Restructure lint.yml to only run auto-fix when lint check fails
  - Add separate lint-check job that runs first
  - Auto-fix job only triggers if lint-check reports failures
  - This improves CI performance by skipping slow auto-fix when not needed

- Update test.yml to run all jobs on OS matrix (Windows, Ubuntu, macOS)
  - test, validate-modules, and security-scan now run on all 3 platforms
  - Removed redundant matrix-test job (consolidated into main test job)
  - Cross-platform path matching in security scan

- Update package.yml to test on all platforms before building
  - Add test job with OS matrix that runs before build
  - Build job now depends on successful cross-platform tests